### PR TITLE
fix/enum-source-registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **Enum class support in `_build_registry_from_source`:** Source code reconstruction now registers `Enum` subclasses alongside `BaseModel` subclasses in the class registry. Previously, dynamically generated enum classes (e.g. from `choices` fields) were invisible to the decoder, causing deserialization failures across process boundaries.
+- **Forward reference resolution in source-reconstructed models:** `_build_registry_from_source` now calls `model_rebuild(_types_namespace=all_types)` on all generated BaseModel classes after exec, so forward references to Enum and other types resolve correctly when `from __future__ import annotations` is present.
+
 ## [v0.4.2] - 2026-04-02
 
 ### Fixed

--- a/kajson/kajson.py
+++ b/kajson/kajson.py
@@ -21,6 +21,7 @@ All additions and modifications are Copyright (c) 2025 Evotis S.A.S.
 """
 
 import datetime
+import enum
 import json
 from typing import IO, Any, Dict, Union
 from zoneinfo import ZoneInfo
@@ -35,22 +36,42 @@ from kajson.json_encoder import UniversalJSONEncoder
 
 
 def _build_registry_from_source(source_code: str) -> ClassRegistry:
-    """Build a ClassRegistry from Python source code by exec'ing it and discovering BaseModel subclasses.
+    """Build a ClassRegistry from Python source code by exec'ing it and discovering classes.
+
+    Registers both BaseModel subclasses and Enum subclasses so that dynamically
+    generated types (e.g. enum classes for choices/constrained fields) can be
+    resolved during deserialization.
 
     WARNING: The source is executed via exec() and can run arbitrary Python code.
     Only pass trusted source code.
 
     Args:
-        source_code: Python source code that defines one or more BaseModel subclasses.
+        source_code: Python source code that defines one or more BaseModel subclasses
+            and optionally Enum subclasses.
 
     Returns:
-        A ClassRegistry containing all discovered BaseModel subclasses.
+        A ClassRegistry containing all discovered BaseModel and Enum subclasses.
     """
     namespace: dict[str, Any] = {}
     exec(compile(source_code, "<kajson_class_source>", "exec"), namespace)
-    registry = ClassRegistry()
-    for name, obj in namespace.items():
+
+    # Collect all user-defined types for forward reference resolution
+    all_types: dict[str, Any] = {name: obj for name, obj in namespace.items() if isinstance(obj, type) and not name.startswith("_")}
+
+    # Rebuild models so forward references (from `from __future__ import annotations`)
+    # resolve against all generated types including Enum classes
+    for name, obj in all_types.items():
         if isinstance(obj, type) and issubclass(obj, BaseModel) and obj is not BaseModel:
+            try:
+                obj.model_rebuild(_types_namespace=all_types)
+            except Exception:
+                pass  # Best-effort: some models may not need rebuilding
+
+    registry = ClassRegistry()
+    for name, obj in all_types.items():
+        if isinstance(obj, type) and issubclass(obj, BaseModel) and obj is not BaseModel:
+            registry.register_class(obj, name=name, should_warn_if_already_registered=False)
+        elif isinstance(obj, type) and issubclass(obj, enum.Enum) and obj is not enum.Enum:
             registry.register_class(obj, name=name, should_warn_if_already_registered=False)
     return registry
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix source registry to include `Enum` classes and resolve forward references in reconstructed models. Prevents decode failures when enums are generated dynamically.

- **Bug Fixes**
  - Register `Enum` subclasses in `_build_registry_from_source` alongside `BaseModel` classes.
  - Call `model_rebuild(_types_namespace=all_types)` on generated `BaseModel` classes so forward references (including to enums) resolve correctly.

<sup>Written for commit 4e80ebf729e22f4f3a6a4fac846a024e38fc2fd0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

